### PR TITLE
Bot can now recognize error input and show simple description

### DIFF
--- a/Classes/errortype.py
+++ b/Classes/errortype.py
@@ -1,0 +1,63 @@
+class ErrorType:
+
+    def __init__(self, name, description):
+        self.name = name
+        self.description = description
+
+
+errors = set([ErrorType('AssertionError', 'Raised when the assert statement fails.'),
+              ErrorType(
+    'AttributeError', 'Raised on the attribute assignment or reference fails.'),
+    ErrorType(
+    'EOFError', 'Raised when the input() function hits the end-of-file condition.'),
+    ErrorType('FloatingPointError',
+              'Raised when a floating point operation fails.'),
+    ErrorType(
+    'GeneratorExit', 'Raised when a generators close() method is called.'),
+    ErrorType(
+    'ImportError', 'Raised when the imported module is not found.'),
+    ErrorType(
+    'IndexError', 'Raised when the index of a sequence is out of range.'),
+    ErrorType(
+    'KeyError', 'Raised when a key is not found in a dictionary.'),
+    ErrorType(
+    'KeyboardInterrupt', 'Raised when the user hits the interrupt key(Ctrl+c or delete).'),
+    ErrorType(
+    'MemoryError', 'Raised when an operation runs out of memory.'),
+    ErrorType(
+    'NameError', 'Raised when a variable is not found in the local or global scope.'),
+    ErrorType('NotImplementedError',
+              'Raised by abstract methods.'),
+    ErrorType(
+    'OSError', 'Raised when a system operation causes a system-related error.'),
+    ErrorType(
+    'OverflowError', 'Raised when the result of an arithmetic operation is too large to be represented.'),
+    ErrorType(
+    'ReferenceError', 'Raised when a weak reference proxy is used to access a garbage collected referent.'),
+    ErrorType(
+    'RuntimeError', 'Raised when an error does not fall under any other category.'),
+    ErrorType('StopIteration', 'Raised by the next() function to indicate that there is no further item to be returned by the iterator.'), ErrorType(
+    'SyntaxError', 'Raised by the parser when a syntax error is encountered.'),
+    ErrorType('IndentationError',
+              'Raised when there is an incorrect indentation.'),
+    ErrorType(
+    'TabError', 'Raised when the indentation consists of inconsistent tabs and spaces.'),
+    ErrorType(
+    'SystemError', 'Raised when the interpreter detects internal error.'),
+    ErrorType('SystemExit',
+              'Raised by the sys.exit() function.'),
+    ErrorType(
+    'TypeError', 'Raised when a function or operation is applied to an object of an incorrect type.'),
+    ErrorType(
+    'UnboundLocalError', 'Raised when a reference is made to a local variable in a function or method, but no value has been bound to that variable.'),
+    ErrorType(
+    'UnicodeError', 'Raised when a Unicode-related encoding or decoding error occurs.'),
+    ErrorType(
+    'UnicodeEncodeError', 'Raised when a Unicode-related error occurs during encoding.'),
+    ErrorType(
+    'UnicodeDecodeError', 'Raised when a Unicode-related error occurs during decoding.'),
+    ErrorType(
+    'UnicodeTranslateError', 'Raised when a Unicode-related error occurs during translation.'),
+    ErrorType(
+    'ValueError', 'Raised when a function gets an argument of correct type but improper value.'),
+    ErrorType('ZeroDivisionError', 'Raised when the second operand of a division or module operation is zero.')])

--- a/cogs/normal/general-normal.py
+++ b/cogs/normal/general-normal.py
@@ -6,6 +6,7 @@ This is a template to create your own discord bot in python.
 Version: 4.1
 """
 
+from tokenize import String
 from exceptions import *
 from typing import TypeVar, Callable
 import json
@@ -14,6 +15,7 @@ import platform
 from pydoc import describe
 import random
 import sys
+from Classes.errortype import errors
 
 import aiohttp
 import disnake
@@ -180,25 +182,28 @@ class General(commands.Cog, name="general-normal"):
     @checks.not_blacklisted()
     async def error_help(self, context: Context) -> None:
 
-        # List of all python error types
-        errors = ['Exception', 'AssertionError', 'AttributeError', 'EOFError', 'FloatingPointError', 'GeneratorExit', 'ImportError', 'IndexError', 'KeyError', 'KeyboardInterrupt', 'MemoryError', 'NameError', 'NotImplementedError', 'OSError', 'OverflowError', 'ReferenceError',
-                  'RuntimeError', 'StopIteration', 'SyntaxError', 'IndentationError', 'TabError', 'SystemError', 'SystemExit', 'TypeError', 'UnboundLocalError', 'UnicodeError', 'UnicodeEncodeError', 'UnicodeDecodeError', 'UnicodeTranslateError', 'ValueError', 'ZeroDivisionError']
-
         # Respond once error command is triggered
         await context.send(f'Hey {context.author.name}, what error are you encountering? Or Type help to get list of errors')
 
-        # Wait for a message from the user who triggered the bot for 60 seconds
-        msg = await context.bot.wait_for("message", check=lambda message: message.author == context.author, timeout=60.0)
+        should_listen = True
+        while should_listen:
 
-        # This is where we'll handle all the logic for determining what the user needs help with
-        if msg.content.lower() == "help":  # Show a list of all errors the user can get help with
-            embed = disnake.Embed(
-                title="**List of Errors:**",
-                description=f"\n".join("**{}**".format(k) for k in errors),
-                color=0x9C84EF
-            )
+            # Wait for a message from the user who triggered the bot for 60 seconds
+            msg = await context.bot.wait_for("message", check=lambda message: message.author == context.author, timeout=60.0)
+            embed = disnake.Embed()
+            
+             # This is where we'll handle all the logic for determining what the user needs help with
+            if msg.content.lower() == "help":  # Show a list of all errors the user can get help with
+                embed.title = "**List of Errors:**"
+                embed.description = f"\n".join("**{}**".format(k.name) for k in errors)
+                embed.set_footer(text="Just type any of these errors and I'll help")
+                embed.color = 0x9C84EF
 
-            embed.footer = "Just type any of these errors and I'll help"
+            elif msg.content.lower() in list(map(lambda error: error.name.lower(), errors)):
+                chosen_error = list(filter(lambda error: error.name.lower() == msg.content.lower(), errors))[0]
+                embed.title = chosen_error.name
+                embed.description = chosen_error.description
+                should_listen = False
 
             await context.send(embed=embed)
 

--- a/cogs/normal/general-normal.py
+++ b/cogs/normal/general-normal.py
@@ -6,9 +6,12 @@ This is a template to create your own discord bot in python.
 Version: 4.1
 """
 
+from exceptions import *
+from typing import TypeVar, Callable
 import json
 import os
 import platform
+from pydoc import describe
 import random
 import sys
 
@@ -17,7 +20,7 @@ import disnake
 from disnake.ext import commands
 from disnake.ext.commands import Context
 
-from helpers import checks
+import helpers.checks as checks
 
 if not os.path.isfile("config.json"):
     sys.exit("'config.json' not found! Please add it and try again.")
@@ -49,7 +52,7 @@ class General(commands.Cog, name="general-normal"):
         )
         embed.add_field(
             name="Owner:",
-            value="Krypton#7331",
+            value="INST126 Dev Team",
             inline=True
         )
         embed.add_field(
@@ -171,59 +174,33 @@ class General(commands.Cog, name="general-normal"):
             await context.send(embed=embed)
 
     @commands.command(
-        name="8ball",
-        description="Ask any question to the bot.",
+        name="error",
+        description="Tell the bot about an error you are encountering and it'll try to help"
     )
     @checks.not_blacklisted()
-    async def eight_ball(self, context: Context, *, question: str) -> None:
-        """
-        Ask any question to the bot.
-        :param context: The context in which the command has been executed.
-        :param question: The question that should be asked by the user.
-        """
-        answers = ["It is certain.", "It is decidedly so.", "You may rely on it.", "Without a doubt.",
-                   "Yes - definitely.", "As I see, yes.", "Most likely.", "Outlook good.", "Yes.",
-                   "Signs point to yes.", "Reply hazy, try again.", "Ask again later.", "Better not tell you now.",
-                   "Cannot predict now.", "Concentrate and ask again later.", "Don't count on it.", "My reply is no.",
-                   "My sources say no.", "Outlook not so good.", "Very doubtful."]
-        embed = disnake.Embed(
-            title="**My Answer:**",
-            description=f"{random.choice(answers)}",
-            color=0x9C84EF
-        )
-        embed.set_footer(
-            text=f"The question was: {question}"
-        )
-        await context.send(embed=embed)
+    async def error_help(self, context: Context) -> None:
 
-    @commands.command(
-        name="bitcoin",
-        description="Get the current price of bitcoin.",
-    )
-    @checks.not_blacklisted()
-    async def bitcoin(self, context: Context) -> None:
-        """
-        Get the current price of bitcoin.
-        :param context: The context in which the command has been executed.
-        """
-        # This will prevent your bot from stopping everything when doing a web request - see: https://discordpy.readthedocs.io/en/stable/faq.html#how-do-i-make-a-web-request
-        async with aiohttp.ClientSession() as session:
-            async with session.get("https://api.coindesk.com/v1/bpi/currentprice/BTC.json") as request:
-                if request.status == 200:
-                    data = await request.json(
-                        content_type="application/javascript")  # For some reason the returned content is of type JavaScript
-                    embed = disnake.Embed(
-                        title="Bitcoin price",
-                        description=f"The current price is {data['bpi']['USD']['rate']} :dollar:",
-                        color=0x9C84EF
-                    )
-                else:
-                    embed = disnake.Embed(
-                        title="Error!",
-                        description="There is something wrong with the API, please try again later",
-                        color=0xE02B2B
-                    )
-                await context.send(embed=embed)
+        # List of all python error types
+        errors = ['Exception', 'AssertionError', 'AttributeError', 'EOFError', 'FloatingPointError', 'GeneratorExit', 'ImportError', 'IndexError', 'KeyError', 'KeyboardInterrupt', 'MemoryError', 'NameError', 'NotImplementedError', 'OSError', 'OverflowError', 'ReferenceError',
+                  'RuntimeError', 'StopIteration', 'SyntaxError', 'IndentationError', 'TabError', 'SystemError', 'SystemExit', 'TypeError', 'UnboundLocalError', 'UnicodeError', 'UnicodeEncodeError', 'UnicodeDecodeError', 'UnicodeTranslateError', 'ValueError', 'ZeroDivisionError']
+
+        # Respond once error command is triggered
+        await context.send(f'Hey {context.author.name}, what error are you encountering? Or Type help to get list of errors')
+
+        # Wait for a message from the user who triggered the bot for 60 seconds
+        msg = await context.bot.wait_for("message", check=lambda message: message.author == context.author, timeout=60.0)
+
+        # This is where we'll handle all the logic for determining what the user needs help with
+        if msg.content.lower() == "help":  # Show a list of all errors the user can get help with
+            embed = disnake.Embed(
+                title="**List of Errors:**",
+                description=f"\n".join("**{}**".format(k) for k in errors),
+                color=0x9C84EF
+            )
+
+            embed.footer = "Just type any of these errors and I'll help"
+
+            await context.send(embed=embed)
 
 
 def setup(bot):

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
-  "prefix": "YOUR_BOT_PREFIX_HERE",
-  "token": "YOUR_BOT_TOKEN_HERE",
+  "prefix": "/",
+  "token": "YOUR_TOKEN_HERE",
   "permissions": "YOUR_BOT_PERMISSIONS_HERE",
   "application_id": "YOUR_APPLICATION_ID_HERE",
   "owners": [


### PR DESCRIPTION
The template utilizes cogs to create abstraction of commands from the bot.py file.  I updated the general-normal cog by removing some fluff commands from the template and defining the new error_help function.  This function will be used to house our logic for the /error command.  I started working on the initial message by the bot and detecting followup response by user.  Currently if the user responds with "help" the bot will list all possible python errors it will be able to help with.